### PR TITLE
Fix file path without extension

### DIFF
--- a/lib/util/walker.js
+++ b/lib/util/walker.js
@@ -116,6 +116,9 @@ function getAbsFilePath(filePath) {
 
 function handleFile(_filePath, appPath, onFile, cachedParsedFile) {
   const filePath = getAbsFilePath(_filePath);
+  if (!filePath) {
+    return;
+  }
 
   if (!shouldParse(filePath) || handledFiles.has(filePath)) {
     return;


### PR DESCRIPTION
Ex: Dockerfile
filePath was undefined and so crashed in path.extname(filePath);