### PR TITLE
Fix fibers/future import check

### DIFF
--- a/lib/rules/no-fibers-future-usage.js
+++ b/lib/rules/no-fibers-future-usage.js
@@ -91,7 +91,7 @@ const isUsingFibersMethods = (node) => {
 
 const includesFibersOrFuturePath = (toTest) => toTest &&
   typeof toTest === "string" &&
-  ["fibers", "future"].some((t) => toTest.toLowerCase().includes(t));
+  ["fibers", "future"].every((t) => toTest.toLowerCase().includes(t));
 
 const isImportingFibersOrFuture = (node) => {
   const isImportDeclaration = node &&

--- a/lib/rules/no-fibers-future-usage.js
+++ b/lib/rules/no-fibers-future-usage.js
@@ -90,8 +90,7 @@ const isUsingFibersMethods = (node) => {
 };
 
 const includesFibersOrFuturePath = (toTest) => toTest &&
-  typeof toTest === "string" &&
-  ["fibers", "future"].every((t) => toTest.toLowerCase().includes(t));
+  typeof toTest === "string" && toTest.toLowerCase().startsWith('fibers')
 
 const isImportingFibersOrFuture = (node) => {
   const isImportDeclaration = node &&

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "rule": "node scripts/new-rule.js",
     "test": "npm run unit-test && npm run coverage:report && npm run coverage:check",
     "unit-test": "nyc --reporter=lcov mocha tests --recursive",
-    "unit-test:watch": "npm run unit-test -s -- --watch -g no-sync-mongo-methods-on-server"
+    "unit-test:watch": "npm run unit-test -s -- --watch"
   },
   "files": [
     "README.md",

--- a/tests/lib/rules/no-fibers-future-usage.js
+++ b/tests/lib/rules/no-fibers-future-usage.js
@@ -34,6 +34,12 @@ ruleTester.run('no-fibers-future-usage', rule, {
       ],
     },
     {
+      code: 'import Fibers from "fibers"',
+      errors: [
+        { message: 'Invalid import/require of Fibers/Future', type: 'ImportDeclaration' },
+      ],
+    },
+    {
       code: 'require("fibers/future")',
       errors: [
         { message: 'Invalid import/require of Fibers/Future', type: 'CallExpression' },

--- a/tests/lib/rules/no-fibers-future-usage.js
+++ b/tests/lib/rules/no-fibers-future-usage.js
@@ -23,6 +23,7 @@ ruleTester.run('no-fibers-future-usage', rule, {
     { code: 'const aa = new Test()' },
     { code: 'Testing(function() {})' },
     { code: 'User.current' },
+    { code: "import isFuture from 'date-fns/isFuture'" }
   ],
 
   invalid: [


### PR DESCRIPTION
Currently it fails for import statements like this:

```
import isFuture from 'date-fns/isFuture
```

Also removed filter from unit-test:watch