### PR TITLE
#5 issue linting meteor collection hooks

### DIFF
--- a/lib/rules/no-sync-mongo-methods-on-server.js
+++ b/lib/rules/no-sync-mongo-methods-on-server.js
@@ -134,6 +134,14 @@ module.exports = {
                 return;
               }
             }
+            if(node.object.type === 'MemberExpression'){
+              // we can ignore longer than 1 call chain
+              debug(
+                `Skipping ${invalidFunction} to be considered error because it was used in a longer than 1 call chain`,
+                { object: node.object }
+              );
+              return;
+            }
             createError({
               context,
               node,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Quave linting rules for ESLint",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/lib/rules/no-sync-mongo-methods-on-server.js
+++ b/tests/lib/rules/no-sync-mongo-methods-on-server.js
@@ -20,6 +20,7 @@ ruleTester.run('no-sync-mongo-methods-on-server', rule, {
   only: true,
   valid: [
     { code: 'TestCollection.findOneAsync()' },
+    { code: 'UserAccess.after.insert((userId, doc) => {})' },
     {
       code: `
       var modulesCursor = ModulesCollection.find();


### PR DESCRIPTION
Fix it by ignoring longer than direct chain calls.

This is a very opinionated code but should handle most scenarios.