### PR TITLE
TS Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 - Add support to `TS` and `TSX` files by `pre-compiling` it with the `typescript` compiler.
+- You can ignore the cache from the `.eslint-meteor-file` by passing `METEOR_ESLINT_PLUGIN_IGNORE_CACHE` as an environment variable.
 
 ## 1.4.2 - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.5.0 - 2024-04-26
+
+### Bug fixes
+
+- Fix error when babel config is not found by returning an empty array.
+- Add guard to `auditArgumentChecks` since `node` could be empty.
+
+### Changes
+
+- Add support to `TS` and `TSX` files by `pre-compiling` it with the `typescript` compiler.
+
 ## 1.4.2 - 2024-03-22
 
 ### Bug fixes

--- a/lib/rules/audit-argument-checks.js
+++ b/lib/rules/audit-argument-checks.js
@@ -47,7 +47,7 @@ module.exports = {
     }
 
     function auditArgumentChecks(node) {
-      if (!isFunction(node.type)) {
+      if (!node || !isFunction(node.type)) {
         return;
       }
 

--- a/lib/rules/no-sync-mongo-methods-on-server.js
+++ b/lib/rules/no-sync-mongo-methods-on-server.js
@@ -79,7 +79,7 @@ module.exports = {
           archList: ['server'],
           isTest,
           onFile: ({ path }) => {
-            debug(`Processing file ${path}`);
+            debug(`Processing file no-sync-mongo-methods-on-server ${path}`);
           },
         });
       },

--- a/lib/rules/no-sync-user-methods-on-server.js
+++ b/lib/rules/no-sync-user-methods-on-server.js
@@ -6,6 +6,7 @@
  */
 
 const { Walker, getInitFolder, shouldSkip } = require('../util/walker');
+const { debug } = require("../util/utilities");
 
 function isCallingUserMethod(node) {
     const isCallExpression = node &&
@@ -49,7 +50,9 @@ module.exports = {
                 new Walker(getInitFolder(context)).walkApp({
                     archList: ['server'],
                     isTest,
-                    onFile: () => {},
+                    onFile: ({ path }) => {
+                        debug(`Processing file no-sync-user-methods-on-server ${path}`);
+                    },
                 });
             },
             CallExpression: function(node) {

--- a/lib/util/parse.js
+++ b/lib/util/parse.js
@@ -148,7 +148,7 @@ module.exports.findImports = function findImports(filePath, ast, appDir) {
       }
 
       if (nodePath.node.arguments[0].type !== 'StringLiteral') {
-        throw new Error('Unable to handle non-string dynamic imports');
+        throw new Error(`Unable to handle non-string dynamic imports at ${filePath}`);
       }
 
       let importPath = nodePath.node.arguments[0].value;

--- a/lib/util/parse.js
+++ b/lib/util/parse.js
@@ -23,7 +23,7 @@ function findBabelConfig(startDir, appDir) {
 
   const parentDir = path.resolve(startDir, '..');
   if (!parentDir.includes(appDir)) {
-    return false;
+    return [];
   }
 
   return findBabelConfig(parentDir, appDir);
@@ -47,10 +47,48 @@ function findModuleResolveConfig(filePath, appDir) {
   }
 }
 
-module.exports = function readAndParse(filePath) {
-  const content = fs.readFileSync(filePath, 'utf-8');
+function precompileTypeScript(filePath, fileContent) {
+  if (filePath && !filePath.endsWith(".ts") && !filePath.endsWith(".tsx")) {
+    throw new Error("Trying to precompile a non TS file");
+  }
 
-  const ast = parse(content, {
+  const ts = require("typescript");
+  try {
+    return ts.transpileModule(fileContent, {
+      filePath,
+      compilerOptions: {
+        target: ts.ScriptTarget.ESNext,
+        // Leave module syntax intact so that Babel/Reify can handle it.
+        module: ts.ModuleKind.ESNext,
+        // This used to be false by default, but appears to have become
+        // true by default around the release of typescript@3.7. It's
+        // important to disable this option because enabling it allows
+        // TypeScript to use helpers like __importDefault, which are much
+        // better handled by Babel/Reify later in the pipeline.
+        esModuleInterop: false,
+        sourceMap: false,
+        inlineSources: false,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        jsx: ts.JsxEmit.React,
+      }
+    });
+  } catch (e) {
+    e.message = `While compiling ${filePath}: ${e.message}`;
+    throw e;
+  }
+}
+
+module.exports = function readAndParse(filePath) {
+  if (!filePath) {
+    throw Error("Missing file path");
+  }
+
+  const fileContent = fs.readFileSync(filePath, 'utf-8');
+  const isTsFile = filePath.endsWith(".ts") || filePath.endsWith("tsx");
+  const codeContent = isTsFile ? precompileTypeScript(filePath, fileContent).outputText : fileContent;
+
+  return parse(codeContent, {
     parser: {
       parse: (source) =>
         meteorBabelParser(source, {
@@ -59,8 +97,6 @@ module.exports = function readAndParse(filePath) {
         }),
     },
   });
-
-  return ast;
 };
 
 module.exports.findImports = function findImports(filePath, ast, appDir) {

--- a/lib/util/walker.js
+++ b/lib/util/walker.js
@@ -53,8 +53,7 @@ function shouldWalk(folderPath, archList) {
 
 function findExt(filePath) {
   const ext = parseableExt.find((possibleExt) => {
-    const exists = fs.existsSync(filePath + possibleExt);
-    return exists;
+    return fs.existsSync(filePath + possibleExt);
   });
 
   if (ext) {
@@ -103,15 +102,11 @@ function getAbsFilePath(filePath) {
   // some files have no ext or are only the ext (.gitignore, .editorconfig, etc.)
   const existingExt =
     path.extname(filePath) || path.basename(filePath).startsWith('.');
-  if (!existingExt) {
+
+  if (!existingExt || !parseableExt.includes(existingExt)) {
     // TODO: should maybe only do this if a file doesn't exists with the given path
     // since we might be importing a file with no extension.
-    const pathWithExt = findExt(filePath);
-    if (!pathWithExt) {
-      return pathWithExt;
-    }
-
-    return pathWithExt;
+    return findExt(filePath);
   }
 
   // TODO: if the file doesn't exist, we must try other extensions
@@ -255,32 +250,27 @@ class Walker {
       debug('Cache is not going to be used');
     }
     this.cachedParsedFile = useCache
-      ? JSON.parse(fs.readFileSync(this.filePath()))
+      ? JSON.parse(fs.readFileSync(this.filePath(), 'utf-8'))
       : {};
   }
-  walkApp({ archList, onFile,  isTest }) {
+  walkApp({ archList, onFile, isTest }) {
     if (Object.keys(this.cachedParsedFile).length > 0) {
       debug('Not walking the app as the cachedParsedFile is already present');
       return;
     }
 
-    let initialServerFile;
     const packageJsonLocation = path.join(this.appPath, 'package.json');
     if (fs.existsSync(packageJsonLocation)) {
-      const content = JSON.parse(fs.readFileSync(packageJsonLocation));
-      const { meteor } = content;
+      const { meteor } = JSON.parse(fs.readFileSync(packageJsonLocation, 'utf-8'));
       if (meteor && meteor.mainModule && meteor.mainModule.server) {
-        initialServerFile = path.join(this.appPath, meteor.mainModule.server);
         debug('Starting from meteor.mainModule.server from package.json', meteor.mainModule.server);
+        handleFile(
+          path.join(this.appPath, meteor.mainModule.server),
+          this.appPath,
+          onFile,
+          this.cachedParsedFile
+        );
       }
-    }
-    if (initialServerFile) {
-      handleFile(
-        initialServerFile,
-        this.appPath,
-        onFile,
-        this.cachedParsedFile
-      );
     } else {
       handleFolder(
         this.appPath,
@@ -290,8 +280,10 @@ class Walker {
         this.cachedParsedFile
       );
     }
+
     fs.writeFileSync(this.filePath(), JSON.stringify(this.cachedParsedFile));
   }
+
   get cachedParsedFile() {
     return this.cachedParsedFile;
   }

--- a/lib/util/walker.js
+++ b/lib/util/walker.js
@@ -220,6 +220,7 @@ function shouldSkip(context) {
   return false;
 }
 
+const IGNORE_CACHE = !!process.env.METEOR_ESLINT_PLUGIN_IGNORE_CACHE;
 const EXPIRES_CACHE_IN_SECONDS = process.env.METEOR_ESLINT_PLUGIN_EXPIRES_CACHE_IN_SECONDS || 5;
 
 const cacheExistsAndIsStillValid = (filePath) => {
@@ -254,7 +255,7 @@ class Walker {
       : {};
   }
   walkApp({ archList, onFile, isTest }) {
-    if (Object.keys(this.cachedParsedFile).length > 0) {
+    if (!IGNORE_CACHE && Object.keys(this.cachedParsedFile).length > 0) {
       debug('Not walking the app as the cachedParsedFile is already present');
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "readline-sync": "^1.4.10",
         "recast": "^0.23.4",
         "reify": "^0.20.12",
+        "typescript": "^5.4.5",
         "validate-commit-msg": "^2.14.0"
       },
       "engines": {
@@ -157,16 +158,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
-      "integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
+      "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-member-expression-to-functions": "^7.23.0",
         "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.20",
+        "@babel/helper-replace-supers": "^7.24.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
         "semver": "^6.3.1"
@@ -292,9 +293,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -316,12 +317,12 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
-      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
+      "integrity": "sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-member-expression-to-functions": "^7.23.0",
         "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
@@ -590,11 +591,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+      "integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -812,12 +813,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
-      "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
+      "integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-plugin-utils": "^7.24.0",
         "@babel/helper-simple-access": "^7.22.5"
       },
       "engines": {
@@ -6546,11 +6547,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "optional": true,
-      "peer": true,
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quave/eslint-plugin-meteor-quave",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "^8.44.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Quave linting rules for ESLint",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "readline-sync": "^1.4.10",
     "recast": "^0.23.4",
     "reify": "^0.20.12",
+    "typescript": "^5.4.5",
     "validate-commit-msg": "^2.14.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR adds support to the `walker` for parsing `ts` and `tsx` files. It also add a flag to ignore the `cache`.

The way to support typescript is to simply compile it before parsing it with `babel.parse` with the `typescript` compiler. We can't really use the babel typescript plugin/preset because it can still cause compilation errors and it would conflict with the `flow` plugin that comes from the babel options from `reify`.

We also added the flag `METEOR_ESLINT_PLUGIN_IGNORE_CACHE` to allow the user to ignore or not the cache. This is needed because there seems to be a race condition between the 2 rules that uses the `walker`, and the end result is the cache file empty. I think this happens only in larger projects because ESLint might run the rules concurrently. I tested with the TS meteor sample and it worked with the cache without a problem. 