### PR TITLE
fix: load all eagerly loaded files and folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.1 and 1.5.2 - 2024-10-15
+
+### Bug fixes
+
+- Fix issue where eager loaded files were not being linted when not using meteor main modules.
+
 ## 1.5.0 - 2024-04-26
 
 ### Bug fixes

--- a/lib/util/walker.js
+++ b/lib/util/walker.js
@@ -275,19 +275,16 @@ class Walker {
         return;
       }
     }
-    if(!fs.existsSync(path.join(this.appPath, 'server'))){
-      debug('No server folder found in the app');
-      return;
-    }
-    debug('Starting from meteor server folder');
+    debug('Starting from eagerly loaded folders');
 
     handleFolder(
-      path.join(this.appPath, 'server'),
+      path.join(this.appPath),
       this.appPath,
       archList,
       onFile,
       this.cachedParsedFile
     );
+
     fs.writeFileSync(this.filePath(), JSON.stringify(this.cachedParsedFile));
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Quave linting rules for ESLint",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
# Load all eagerly loaded files and folders

## Problem
Previously, the linter was only checking files within the `server` folder, which could miss eagerly loaded files and folders outside of this directory. This led to incomplete linting coverage for Meteor projects not using main modules.

## Solution
This PR modifies the `Walker` class to start from the root app directory instead of specifically the `server` folder. This change ensures that all eagerly loaded files and folders are included in the linting process, regardless of their location in the project structure.

## Changes
- Updated `lib/util/walker.js` to start walking from the app root directory
- Removed the check for the existence of the `server` folder
- Updated CHANGELOG.md to reflect the bug fix in versions 1.5.1 and 1.5.2
- Bumped package version to 1.5.2 in package.json
