### PR TITLE
Fix: ignore chain in update collection method

### DIFF
--- a/lib/rules/no-sync-mongo-methods-on-server.js
+++ b/lib/rules/no-sync-mongo-methods-on-server.js
@@ -134,7 +134,8 @@ module.exports = {
                 return;
               }
             }
-            if(node.object.type === 'MemberExpression'){
+            // this means it's a call chain like crypto.createHmac().update()
+            if(['MemberExpression', 'CallExpression'].includes(node.object.type) && node.type === 'MemberExpression'){
               // we can ignore longer than 1 call chain
               debug(
                 `Skipping ${invalidFunction} to be considered error because it was used in a longer than 1 call chain`,

--- a/tests/lib/rules/no-sync-mongo-methods-on-server.js
+++ b/tests/lib/rules/no-sync-mongo-methods-on-server.js
@@ -48,6 +48,13 @@ ruleTester.run('no-sync-mongo-methods-on-server', rule, {
       modules.fetch();
       `,
     },
+    {
+      code: `
+      crypto
+        .createHmac('sha256', secretIntercomKey)
+        .update(userId);
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
# Fix ESLint rule to properly handle method chains

## Problem
The ESLint rule `no-sync-mongo-methods-on-server` was incorrectly flagging method chains as errors when they weren't MongoDB-related sync operations. Specifically, it wasn't properly handling cases where the chain included `CallExpression` types, such as in `crypto.createHmac().update()`.

## Solution
Enhanced the method chain detection to consider both `MemberExpression` and `CallExpression` types in the object chain. This allows the rule to properly skip validation for non-MongoDB method chains while still catching actual sync MongoDB operations.

## Changes
- Added support for `CallExpression` in the chain detection logic
- Added test case for `crypto.createHmac().update()` to verify the fix
- Added clarifying comment explaining the purpose of the chain detection
