### PR TITLE
Handle non-string dynamic imports gracefully

### DIFF
--- a/lib/util/parse.js
+++ b/lib/util/parse.js
@@ -149,7 +149,8 @@ module.exports.findImports = function findImports(filePath, ast, appDir) {
       }
 
       if (nodePath.node.arguments[0].type !== 'StringLiteral') {
-        throw new Error(`Unable to handle non-string dynamic imports at ${filePath}`);
+        console.warn(`[meteor-quave] Warning: Unable to resolve non-string dynamic import at ${filePath}. This import will be skipped.`);
+        return this.traverse(nodePath);
       }
 
       let importPath = nodePath.node.arguments[0].value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quave/eslint-plugin-meteor-quave",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "babel-plugin-module-resolver": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quave/eslint-plugin-meteor-quave",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Quave linting rules for ESLint",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- When a dynamic import uses a variable instead of a string literal (e.g. `await import(varName)`), the parser now logs a warning and skips the import instead of crashing the entire lint run.
- This was encountered in a large Meteor project where Sentry was dynamically imported based on a runtime condition.

## Test plan
- [x] Verified on a large Meteor 2 codebase (~3000+ files) that the plugin no longer crashes
- [x] Warning is logged so users are aware the import was skipped